### PR TITLE
Add more extra text to building type search results

### DIFF
--- a/api/search.js
+++ b/api/search.js
@@ -361,10 +361,15 @@
                                     extraText = result.english["old"];
                                 }
                             } else {
-                                if (typeof data.sort !== "undefined" && data.sort === "JIBEON") {
+                                if (/BUILDING/.test(data.type)) {
+                                    mainText = result.address["base"] + " " + result.address["old"];
+                                    extraText = result.address["new"] + " " + result.other["others"];
+                                }
+                                else if (typeof data.sort !== "undefined" && data.sort === "JIBEON") {
                                     mainText = result.address["base"] + " " + result.address["old"];
                                     extraText = result.address["new"];
-                                } else {
+                                }
+                                else {
                                     mainText = result.address["base"] + " " + result.address["new"];
                                     extraText = result.other["long"];
                                 }


### PR DESCRIPTION
아파트명이나 건물명으로 검색했을때(`방배동 래미안`, `세종문화회관`) 구주소와
도로명주소가 나타납니다.

그런데 일반적으로 아파트에 대해서는 구주소와 도로명 주소를 잘 사용하지
않기 때문에 검색결과를 봐도 모르는 경우가 많습니다.

해서, 건물명으로 검색했을 경우엔 추가정보를 나타냅니다.

![a](https://cloud.githubusercontent.com/assets/170528/6438078/16640a98-c109-11e4-8421-b74d628bfe9a.png)
![b](https://cloud.githubusercontent.com/assets/170528/6438080/1665860c-c109-11e4-8497-6105e55df1a8.png)

![c](https://cloud.githubusercontent.com/assets/170528/6438079/166520a4-c109-11e4-9d4e-75bc978be4d8.png)
![d](https://cloud.githubusercontent.com/assets/170528/6438081/16683c1c-c109-11e4-919e-2e88ed5864d5.png)


